### PR TITLE
Use HTTPS to access stylesheet to avoid errors

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>twauth-web sample app {% block title %}{% endblock %}</title>
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
   </head>
 
   <body>


### PR DESCRIPTION
Without using https, Chrome may not load the insecure content so the pages remain unstyled (depending on config). Fortunately the CDN also presents an https URL.
